### PR TITLE
Fix the problem that default sink fails to get

### DIFF
--- a/viper
+++ b/viper
@@ -24,7 +24,7 @@ start () {
 		declare $(head -n1 $devicefile) #get location and desc from file
 	else
 		#Do our best.
-		location=$(pactl info | grep "Default Sink" | awk -F ": " '{print $2}')
+		location=$(LANG=C pactl info | grep "Default Sink" | awk -F ": " '{print $2}')
 		if [ "$location" == "$vipersink" ]; then echo "Something is very wrong (Target is same as our vipersink name)."; return; fi
 	fi
 	idnum=$(pactl load-module module-null-sink sink_name=$vipersink sink_properties=device.description="Viper4Linux")


### PR DESCRIPTION
The language output by pactl will change according to the system language. When LANG is non-English, such as zh_CN.UTF-8, the output content will be Chinese, and the Default Sink will also be Chinese, which will affect the final result.